### PR TITLE
Adding missing properties to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,21 @@
 {
   "name": "tincan",
+  "description": "A WebRTC demonstration",
   "version": "0.0.1",
+  "author": {
+    "name" : "Mozilla",
+    "url" : "https://mozilla.org/"
+  },
+  "licenses" : [{
+    "type": "MPL 2.0",
+    "url": "https://mozilla.org/MPL/2.0/"
+  }],
+  "homepage": "http://tincan.im/",
+  "bugs": "https://github.com/mozilla/tincan/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mozilla/tincan"
+  },
   "private": true,
   "dependencies": {
     "express": "2.5.x",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "private": true,
   "dependencies": {
     "express": "2.5.x",
-    "stylus": ">= 0.0.1",
-    "jade": ">= 0.0.1",
+    "stylus": ">=0.0.1",
+    "jade": ">=0.0.1",
     "socket.io": "0.9.x",
     "request": "~2.21.0"
   },


### PR DESCRIPTION
Fixes #24

I tweaked the stylus/jade versions to remove the space between ">=" and the version number, per https://npmjs.org/doc/misc/semver.html. It was probably fine as it was, but now it isn't throwing errors in http://package-json-validator.com/.
